### PR TITLE
Fix issue with configuration loading

### DIFF
--- a/src/Import/ConfigurationFactory.php
+++ b/src/Import/ConfigurationFactory.php
@@ -17,6 +17,38 @@ class ConfigurationFactory
         return $config;
     }
 
+    public static function initialize(Configuration $config, array $importers)
+    {
+        $iKeys = $config->importerKeys;
+        $sKeys = $config->segmentKeys;
+
+        foreach ($importers as $importer) {
+            $config->addImporter($importer);
+        }
+        if (empty($iKeys) && empty($sKeys)) {
+            return;
+        }
+
+        foreach ($config->getImporters(true) as $importer) {
+            $importer->disable();
+            $key = $importer->getKey();
+            if (array_key_exists($key, $iKeys) && true === $iKeys[$key]) {
+                $importer->enable();
+            }
+        }
+
+        foreach ($config->getSegments(true) as $segment) {
+            $segment->disable();
+            $key = $segment->getKey();
+            if (array_key_exists($key, $sKeys) && true === $sKeys[$key]) {
+                $segment->enable();
+            }
+        }
+
+        $config->importerKeys = $iKeys;
+        $config->segmentKeys = $sKeys;
+    }
+
     public static function load($filename)
     {
         $config = unserialize(file_get_contents($filename));

--- a/src/Import/Manager.php
+++ b/src/Import/Manager.php
@@ -52,11 +52,7 @@ class Manager
     public function create()
     {
         $this->configuration = ConfigurationFactory::create($this->contextKey);
-        foreach ($this->importers as $importer) {
-            if ($importer->supports($this->configuration)) {
-                $this->configuration->addImporter($importer);
-            }
-        }
+        ConfigurationFactory::initialize($this->configuration, $this->importers);
         return $this->configuration;
     }
 
@@ -64,19 +60,8 @@ class Manager
     {
         $path = sprintf('%s/%s', $this->storagePath, $filename);
         $this->configuration = ConfigurationFactory::load($path);
-        $this->initializeConfiguration();
+        ConfigurationFactory::initialize($this->configuration, $this->importers);
         return $this->configuration;
-    }
-
-    /**
-     * Translate keys for importers and segments back into the currently loaded services.
-     */
-    private function initializeConfiguration()
-    {
-        foreach ($this->importers as $importer) {
-            $enabled = in_array($importer->getKey(), $this->configuration->getImporterKeys());
-            $this->configuration->addImporter($importer, $enabled);
-        }
     }
 
     public function save()

--- a/src/Import/Persister/As3Modlr.php
+++ b/src/Import/Persister/As3Modlr.php
@@ -68,7 +68,7 @@ final class As3Modlr extends Persister
      */
     public function getModelTypes()
     {
-        $types = ['location', 'tag-family', 'tag', 'publication', 'publication-issue', 'publication-section', 'publication-section-award'];
+        $types = [];
         return array_unique(array_merge($types, $this->storageEngine->getModelTypes()));
     }
 
@@ -111,29 +111,6 @@ final class As3Modlr extends Persister
         }
 
         if (Configuration::SCHEMA_MODE_NONE !== $mode = $this->configuration->getSchemaMode()) {
-            $indices = [
-                [
-                    'fields'    => ['legacy.id' => 1, 'legacy.source' => 1],
-                    'options'   => ['unique' => true, 'sparse' => true]
-                ],
-                [
-                    'fields'    => ['urlPath' => 1, 'deleted' => 1],
-                    'options'   => []
-                ],
-                [
-                    'fields'    => ['redirects' => 1, 'deleted' => 1],
-                    'options'   => []
-                ],
-                [
-                    'fields'    => ['name' => 'text'],
-                    'options'   => ['textIndexVersion'  => 2]
-                ]
-            ];
-            foreach ($this->storageEngine->getModelTypes() as $type) {
-                foreach ($indices as $index) {
-                    $this->getCollectionForModel($type)->ensureIndex($index['fields'], $index['options']);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Previously loaded configurations were not respecting the serialized configuration of enabled/disabled importers and segments. This PR changes the logic to now initialize a configuration after loading and set the previously selected status on importers and segments.